### PR TITLE
chore(core_ext) JSON.safe_parse

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ require 'graphiti/rails/railtie'
 # core_ext
 require_relative "../lib/core_ext/rails/settings"
 require_relative "../lib/core_ext/ruby/array/intersect"
+require_relative "../lib/core_ext/ruby/json/safe_parse"
 require_relative "../lib/core_ext/rails/active_support/time"
 require_relative "../app/lib/clean_backtrace_formatter"
 
@@ -87,7 +88,13 @@ module HouseNinja
         headers = {}
         request.headers.each do |key, value|
           if key.is_a?(String) && key.start_with?("HTTP_")
-            headers[key] = value
+            case key
+            when "HTTP_X_HN_USER_PERMISSIONS"
+            when "HTTP_X_JWT_CLAIMS"
+              headers[key] = JSON.safe_parse(value)
+            else
+              headers[key] = value
+            end
           end
         end
         headers.except(

--- a/lib/core_ext/ruby/json/safe_parse.rb
+++ b/lib/core_ext/ruby/json/safe_parse.rb
@@ -1,0 +1,18 @@
+module JSON
+  # Safely parse JSON without raising an exception
+  #
+  # @example
+  #   JSON.safe_parse("not_json") #=> nil
+  #   JSON.safe_parse('{ "some": "json" }') #=> { "some" => "json" }
+  #
+  # @param [String] json
+  # @param [Hash] options
+  # @return [Hash, Array, String, Integer, Float, true, false, nil]
+  def self.safe_parse(json, options = {})
+    begin
+      ::JSON.parse(json, options)
+    rescue ::JSON::ParserError
+      nil
+    end
+  end
+end

--- a/spec/lib/core_ext/ruby/json/safe_parse_spec.rb
+++ b/spec/lib/core_ext/ruby/json/safe_parse_spec.rb
@@ -1,0 +1,24 @@
+# spec/lib/json_spec.rb
+require 'rails_helper'
+
+# require 'lib/core_ext/ruby/json/safe_parse'
+
+require_relative '../../../../../lib/core_ext/ruby/json/safe_parse'
+
+RSpec.describe JSON do
+  context 'class methods' do
+    subject { JSON }
+
+    it { is_expected.to respond_to(:safe_parse) }
+  end
+
+  describe '.safe_parse' do
+    it 'should return nil for invalid json' do
+      JSON.safe_parse('not json').should be_nil
+    end
+
+    it 'should return a ruby hash for valid json' do
+      JSON.safe_parse('{ "some": "json" }').should == { 'some' => 'json' }
+    end
+  end
+end


### PR DESCRIPTION
This adds a core_ext for parsing JSON without worrying about exception handling within just a one-liner. Additionally it json-parses a few specific HTTP headers before forwarding them to datadog